### PR TITLE
Update for Julia 1.0 compatibility

### DIFF
--- a/src/ILU0.jl
+++ b/src/ILU0.jl
@@ -134,8 +134,8 @@ module ILU0
     end
 
     import LinearAlgebra: ldiv!
-    # Solves LU\b overwriting b
-    function ldiv!(LU::ILU0Precon{T,N}, b::AbstractVector{T}) where {T<:Real,N<:Integer}
+    # Solves LU\b overwriting x
+    function ldiv!(x::AbstractVector{T}, LU::ILU0Precon{T,N}, b::AbstractVector{T}) where {T<:Real,N<:Integer}
         (length(b) == LU.n) || throw(DimensionMismatch())
         n = LU.n
         l_colptr = LU.l_colptr
@@ -155,17 +155,16 @@ module ILU0
             end
         end
         @inbounds for i = n:-1:1
-            b[i] = wrk[i]/u_nzval[u_colptr[i+1]-1]
+            x[i] = wrk[i]/u_nzval[u_colptr[i+1]-1]
             for j = u_colptr[i]:u_colptr[i+1]-2
-                wrk[u_rowval[j]] -= u_nzval[j]*b[i]
+                wrk[u_rowval[j]] -= u_nzval[j]*x[i]
             end
         end
     end
 
-    # Solves Lu\b overwriting x
-    function ldiv!(x::AbstractVector{T}, LU::ILU0Precon{T,N}, b::AbstractVector{T}) where {T<:Real,N<:Integer}
-        x .= b
-        ldiv!(LU, x)
+    # Solves Lu\b overwriting b
+    function ldiv!(LU::ILU0Precon{T,N}, b::AbstractVector{T}) where {T<:Real,N<:Integer}
+        ldiv!(b, LU, b)
     end
 
     import Base: \
@@ -173,7 +172,7 @@ module ILU0
     function \(LU::ILU0Precon{T,N}, b::Vector{T}) where {T<:Real,N<:Integer}
         length(b) == LU.n || throw(DimensionMismatch())
         x = zeros(T, length(b))
-        A_ldiv_B!(x, LU, b)
+        ldiv!(x, LU, b)
         return x
     end
 

--- a/src/ILU0.jl
+++ b/src/ILU0.jl
@@ -1,9 +1,8 @@
 module ILU0
-    # Overloaded functions
-    import Base: \, A_ldiv_B!
+    using LinearAlgebra, SparseArrays
 
     # ILU0 type definition
-    immutable ILU0Precon{T<:Real,N<:Integer} <: Factorization{T}
+    struct ILU0Precon{T<:Real,N<:Integer} <: Factorization{T}
         m::N
         n::N
         l_colptr::Vector{N}
@@ -18,7 +17,7 @@ module ILU0
     end
 
     # Allocates ILU0Precon type
-    function ILU0Precon{T<:Real,N<:Integer}(A::SparseMatrixCSC{T,N})
+    function ILU0Precon(A::SparseMatrixCSC{T,N}) where {T<:Real, N<:Integer}
         m, n = size(A)
 
         # Determine number of elements in lower/upper
@@ -41,8 +40,8 @@ module ILU0
         u_nzval = zeros(T, unz)
         l_rowval = zeros(Int64, lnz)
         u_rowval = zeros(Int64, unz)
-        l_map = Vector{N}(lnz)
-        u_map = Vector{N}(unz)
+        l_map = Vector{N}(undef, lnz)
+        u_map = Vector{N}(undef, unz)
         wrk = zeros(T, n)
         l_colptr[1] = 1
         u_colptr[1] = 1
@@ -72,7 +71,7 @@ module ILU0
     end
 
     # Updates ILU0Precon type in-place based on matrix A
-    function ilu0!{T<:Real,N<:Integer}(LU::ILU0Precon{T,N}, A::SparseMatrixCSC{T,N})
+    function ilu0!(LU::ILU0Precon{T,N}, A::SparseMatrixCSC{T,N}) where {T<:Real, N<:Integer}
         m = LU.m
         n = LU.n
         l_colptr = LU.l_colptr
@@ -128,14 +127,14 @@ module ILU0
     end
 
     # Constructs ILU0Precon type based on matrix A
-    function ilu0{T<:Real,N<:Integer}(A::SparseMatrixCSC{T,N})
+    function ilu0(A::SparseMatrixCSC{T,N}) where {T<:Real,N<:Integer}
         LU = ILU0Precon(A)
         ilu0!(LU, A)
         return LU
     end
 
     # Solves LU\b overwriting x
-    function A_ldiv_B!{T<:Real,N<:Integer}(x::Vector{T}, LU::ILU0Precon{T,N}, b::Vector{T})
+    function A_ldiv_B!(x::Vector{T}, LU::ILU0Precon{T,N}, b::Vector{T}) where {T<:Real,N<:Integer}
         (length(b) == LU.n && length(x) == LU.n) || throw(DimensionMismatch())
         n = LU.n
         l_colptr = LU.l_colptr
@@ -164,8 +163,9 @@ module ILU0
         return
     end
 
+    import Base: \
     # Returns LU\b
-    function \{T<:Real,N<:Integer}(LU::ILU0Precon{T,N}, b::Vector{T})
+    function \(LU::ILU0Precon{T,N}, b::Vector{T}) where {T<:Real,N<:Integer}
         length(b) == LU.n || throw(DimensionMismatch())
         x = zeros(T, length(b))
         A_ldiv_B!(x, LU, b)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,12 +7,12 @@ function test_solve()
     n = 100
     tA = sprandn(n,n,.1) + 10.0*I
     A = tA'*tA
-    LU = ilu0(A)
+    ilu_prec = ilu0(A)
     b = rand(n)
     x, ch = cg(A, b, log=true)
     nocon_niter = ch.iters
     println("No preconditioning: ", nocon_niter, " iterations")
-    x, ch = cg(A, b, Pl=LU, log=true)
+    x, ch = cg(A, b, Pl=ilu_prec, log=true)
     con_niter = ch.iters
     println("Preconditioned: ", con_niter, " iterations")
     if nocon_niter > con_niter

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,15 +1,14 @@
 #!/usr/bin/env julia
 
 #Start Test Script
-using ILU0
-using IterativeSolvers
-using Base.Test
+using ILU0, IterativeSolvers, LinearAlgebra, SparseArrays, Test
 
 function test_solve()
-    tA = sprandn(100,100,.1) + 10.0*speye(100)
+    n = 100
+    tA = sprandn(n,n,.1) + 10.0*I
     A = tA'*tA
     LU = ilu0(A)
-    b = rand(100)
+    b = rand(n)
     x, ch = cg(A, b, log=true)
     nocon_niter = ch.iters
     println("No preconditioning: ", nocon_niter, " iterations")


### PR DESCRIPTION
Update the syntax for Julia 1.0. Also, update the preconditioning interface for compatibility with new versions of [IterativeSolvers.jl](https://github.com/JuliaMath/IterativeSolvers.jl). Added a method `ldiv!` that overwrites `x` (but not `b`). This is in addition to the existing `ldiv!` that overwrites `b`.