### PR TITLE
Fixes to construct matrix of matrices ILU(0) preconditioners

### DIFF
--- a/src/ILUZero.jl
+++ b/src/ILUZero.jl
@@ -138,12 +138,13 @@ function ilu0(A::SparseMatrixCSC{T,N}, arg...) where {T <: Any,N <: Integer}
 end
 
 # Solves L\b and stores the solution in y
-function forward_substitution!(y::AbstractVector{T}, LU::ILU0Precon{T,N}, b::AbstractVector{T}) where {T <: Any,N <: Integer}
+function forward_substitution!(y::AbstractVector{T}, LU::ILU0Precon{T,N,M}, b::AbstractVector{T}) where {T, N <: Integer, M}
     n = LU.n
     l_colptr = LU.l_colptr
     l_rowval = LU.l_rowval
     l_nzval  = LU.l_nzval
 
+    wrk = LU.wrk
     for i in eachindex(wrk)
         wrk[i] = zero(M)
     end

--- a/src/ILUZero.jl
+++ b/src/ILUZero.jl
@@ -112,7 +112,7 @@ function ilu0!(LU::ILU0Precon{T,N}, A::SparseMatrixCSC{T,N}) where {T <: Any,N <
                     qn += 1
                 end
                 if qn < u_colptr[i + 2] && l_rowval[pn] == u_rowval[qn]
-                    u_nzval[qn] -= multiplier * l_nzval[pn]
+                    u_nzval[qn] -= l_nzval[pn] * multiplier
                 end
                 pn += 1
             end
@@ -121,7 +121,7 @@ function ilu0!(LU::ILU0Precon{T,N}, A::SparseMatrixCSC{T,N}) where {T <: Any,N <
                     rn += 1
                 end
                 if rn < l_colptr[i + 2] && l_rowval[pn] == l_rowval[rn]
-                    l_nzval[rn] -= multiplier * l_nzval[pn]
+                    l_nzval[rn] -= l_nzval[pn] * multiplier
                 end
                 pn += 1
             end

--- a/src/ILUZero.jl
+++ b/src/ILUZero.jl
@@ -138,7 +138,7 @@ function ilu0(A::SparseMatrixCSC{T,N}, arg...) where {T <: Any,N <: Integer}
 end
 
 # Solves L\b and stores the solution in y
-function forward_substitution!(y::AbstractVector{T}, LU::ILU0Precon{T,N,M}, b::AbstractVector{T}) where {T, N <: Integer, M}
+function forward_substitution!(y, LU::ILU0Precon{T,N,M}, b) where {T, N <: Integer, M}
     n = LU.n
     l_colptr = LU.l_colptr
     l_rowval = LU.l_rowval

--- a/src/ILUZero.jl
+++ b/src/ILUZero.jl
@@ -144,7 +144,9 @@ function forward_substitution!(y::AbstractVector{T}, LU::ILU0Precon{T,N}, b::Abs
     l_rowval = LU.l_rowval
     l_nzval  = LU.l_nzval
 
-    y .= zero(T)
+    for i in eachindex(wrk)
+        wrk[i] = zero(M)
+    end
 
     @inbounds for i = 1:n
         y[i] += b[i]

--- a/src/ILUZero.jl
+++ b/src/ILUZero.jl
@@ -98,9 +98,9 @@ function ilu0!(LU::ILU0Precon{T,N}, A::SparseMatrixCSC{T,N}) where {T <: Any,N <
 
 
     @inbounds for i = 1:m - 1
-        multiplier = u_nzval[u_colptr[i + 1] - 1]
+        m_inv = inv(u_nzval[u_colptr[i + 1] - 1])
         for j = l_colptr[i]:l_colptr[i + 1] - 1
-            l_nzval[j] /= multiplier
+            l_nzval[j] = m_inv * l_nzval[j]
         end
         for j = u_colptr[i + 1]:u_colptr[i + 2] - 2
             multiplier = u_nzval[j]

--- a/src/ILUZero.jl
+++ b/src/ILUZero.jl
@@ -144,9 +144,8 @@ function forward_substitution!(y::AbstractVector{T}, LU::ILU0Precon{T,N,M}, b::A
     l_rowval = LU.l_rowval
     l_nzval  = LU.l_nzval
 
-    wrk = LU.wrk
-    for i in eachindex(wrk)
-        wrk[i] = zero(M)
+    for i in eachindex(y)
+        y[i] = zero(M)
     end
 
     @inbounds for i = 1:n

--- a/src/ILUZero.jl
+++ b/src/ILUZero.jl
@@ -100,7 +100,7 @@ function ilu0!(LU::ILU0Precon{T,N}, A::SparseMatrixCSC{T,N}) where {T <: Any,N <
     @inbounds for i = 1:m - 1
         m_inv = inv(u_nzval[u_colptr[i + 1] - 1])
         for j = l_colptr[i]:l_colptr[i + 1] - 1
-            l_nzval[j] = m_inv * l_nzval[j]
+            l_nzval[j] = l_nzval[j] * m_inv
         end
         for j = u_colptr[i + 1]:u_colptr[i + 2] - 2
             multiplier = u_nzval[j]


### PR DESCRIPTION
The PR includes a few additional fixes that follow PR #6 to allow for the use of ILU(0) as a preconditioner for matrices where the entries are not scalars. The specific changes are as follows:
- Add an optional input argument to specify the right hand side type (if the matrix entries are N by N blocks, then the rhs and solution are N vectors)
- Switch the divisions to from `rdiv` to `ldiv` which shouldn't change the output for scalars, but is important for matrix division.
- Avoid broadcasting for zeroing the work memory since it errors for non-scalars.
